### PR TITLE
Fix: Resize the window to avoid scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 <!-- partial:index.partial.html -->
 <div class="pg-orgchart">
-  <div style="overflow: auto; width: 1100px;">
+  <div style="overflow: auto; width: 1200px;">
   <div class="org-chart"  style="width: 1170px;">
 		<ul>
       <li>


### PR DESCRIPTION
With the width set to 1100 pixels a horizontal scrollbar appears in the org. chart. Setting the width to 1200 pixels removes it.